### PR TITLE
PHP 7.4 part 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,12 @@
         "psr/log": "*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.11",
-        "symfony/http-client": "^5.4"
+        "phpstan/phpstan": "^1.11"
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": false
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     ports:
-      - "9009:9000"
+      - "9022:9000"
     volumes:
       - ./:/var/www/html:delegated


### PR DESCRIPTION
- To avoid a port number collision with another project, randomly change port forwarding in Docker
- Because the symfony/http-client isn't being used, delete the requirement and the plugin that keeps installing it