### PR TITLE
Expand on HttpException to include specific restful errors, connection errors and library marker interface

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -18,7 +18,7 @@ use Upmind\Sdk\Config;
 use Upmind\Sdk\Data\AbstractParams;
 use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Logging\DefaultLogger;
 use Upmind\Sdk\Services\Clients\AddressService;
 use Upmind\Sdk\Services\Clients\ClientService;

--- a/src/Api.php
+++ b/src/Api.php
@@ -14,11 +14,17 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Throwable;
 use Upmind\Sdk\Config;
 use Upmind\Sdk\Data\AbstractParams;
 use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
+use Upmind\Sdk\Exceptions\AuthException;
+use Upmind\Sdk\Exceptions\ClientException;
+use Upmind\Sdk\Exceptions\ConnectionException;
 use Upmind\Sdk\Exceptions\HttpException;
+use Upmind\Sdk\Exceptions\ServerException;
+use Upmind\Sdk\Exceptions\ValidationException;
 use Upmind\Sdk\Logging\DefaultLogger;
 use Upmind\Sdk\Services\Clients\AddressService;
 use Upmind\Sdk\Services\Clients\ClientService;
@@ -183,12 +189,14 @@ class Api
                 );
         }
 
-        $response = new ApiResponse($this->httpClient->sendRequest($request));
+        try {
+            $response = new ApiResponse($this->httpClient->sendRequest($request));
+        } catch (Throwable $e) {
+            $this->throwConnectionException($e);
+        }
 
-        $error = $response->getResponseError();
-
-        if ($this->config->restfulExceptions() && $error) {
-            throw new HttpException($response, $error);
+        if ($this->config->restfulExceptions() && !$response->isSuccessful()) {
+            $this->throwHttpException($response);
         }
 
         return $response;
@@ -227,5 +235,43 @@ class Api
             \Composer\InstalledVersions::getVersion('upmind/sdk') ?? 'dev',
             PHP_VERSION
         );
+    }
+
+    /**
+     * @return no-return|never
+     *
+     * @throws ConnectionException
+     */
+    private function throwConnectionException(Throwable $e): void
+    {
+        throw new ConnectionException($e->getMessage(), $e->getCode(), $e);
+    }
+
+    /**
+     * @return no-return|never
+     *
+     * @throws HttpException
+     */
+    private function throwHttpException(ApiResponse $response): void
+    {
+        $httpCode = $response->getHttpCode();
+
+        if ($httpCode === 401) {
+            throw new AuthException($response);
+        }
+
+        if ($httpCode === 422) {
+            throw new ValidationException($response);
+        }
+
+        if ($httpCode >= 400 && $httpCode < 500) {
+            throw new ClientException($response);
+        }
+
+        if ($httpCode >= 500) {
+            throw new ServerException($response);
+        }
+
+        throw new HttpException($response, 'Unexpected Error');
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config
      * @param bool $debug Whether or not to stream API requests + responses to STDERR by default
      * @param string $hostname
      * @param string $protocol
-     * @param bool $restfulExceptions
+     * @param bool $restfulExceptions Set to false to disable HttpExceptions for API error responses
      */
     public function __construct(
         string $token,
@@ -33,7 +33,7 @@ class Config
         bool $debug = false,
         string $hostname = 'api.upmind.io',
         string $protocol = 'https',
-        bool $restfulExceptions = false
+        bool $restfulExceptions = true
     ) {
         $this->token = $token;
         $this->brandId = $brandId;

--- a/src/Exceptions/AuthException.php
+++ b/src/Exceptions/AuthException.php
@@ -25,6 +25,6 @@ class AuthException extends ClientException
      */
     protected function getHint(): ?string
     {
-        return $this->getResponse()->getResponseMessages()['hint'] ?? null;
+        return $this->getApiResponse()->getResponseMessages()['hint'] ?? null;
     }
 }

--- a/src/Exceptions/AuthException.php
+++ b/src/Exceptions/AuthException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+use Upmind\Sdk\Data\ApiResponse;
+
+/**
+ * Exception thrown for API authentication (401) errors.
+ *
+ * @see \Upmind\Sdk\Config::restfulExceptions()
+ */
+class AuthException extends ClientException
+{
+    public function __construct(ApiResponse $apiResponse, ?string $message = null)
+    {
+        $this->apiResponse = $apiResponse;
+        $message = $message ?: $this->getHint();
+        parent::__construct($apiResponse, $message);
+    }
+
+    /**
+     * Hint for solving the issue.
+     */
+    protected function getHint(): ?string
+    {
+        return $this->getResponse()->getResponseMessages()['hint'] ?? null;
+    }
+}

--- a/src/Exceptions/ClientException.php
+++ b/src/Exceptions/ClientException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+/**
+ * Exception thrown for API client (4xx) errors.
+ *
+ * @see \Upmind\Sdk\Config::restfulExceptions()
+ */
+class ClientException extends HttpException
+{
+    //
+}

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+/**
+ * Exception thrown for API connection/ssl errors.
+ */
+class ConnectionException extends \Exception implements UpmindSdkException
+{
+    //
+}

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -19,7 +19,7 @@ class HttpException extends \Exception implements UpmindSdkException
     public function __construct(ApiResponse $apiResponse, ?string $message = null)
     {
         $this->apiResponse = $apiResponse;
-        $message = $message ?: $this->getError()->getMessage();
+        $message = $message ?: $this->getApiError()->getMessage();
         parent::__construct($message, $this->getHttpCode());
     }
 
@@ -28,12 +28,12 @@ class HttpException extends \Exception implements UpmindSdkException
         return $this->apiResponse->getHttpCode();
     }
 
-    public function getResponse(): ApiResponse
+    public function getApiResponse(): ApiResponse
     {
         return $this->apiResponse;
     }
 
-    public function getError(): ApiError
+    public function getApiError(): ApiError
     {
         return $this->apiResponse->getResponseError();
     }

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -4,29 +4,37 @@ declare(strict_types=1);
 
 namespace Upmind\Sdk\Exceptions;
 
-use Psr\Http\Message\ResponseInterface;
 use Upmind\Sdk\Data\ApiError;
+use Upmind\Sdk\Data\ApiResponse;
 
-class HttpException extends \Exception
+/**
+ * Exception thrown for API error responses.
+ *
+ * @see \Upmind\Sdk\Config::restfulExceptions()
+ */
+class HttpException extends \Exception implements UpmindSdkException
 {
-    private ResponseInterface $response;
+    protected ApiResponse $apiResponse;
 
-    private ApiError $apiError;
-
-    public function __construct(ResponseInterface $response, ApiError $apiError)
+    public function __construct(ApiResponse $apiResponse, ?string $message = null)
     {
-        parent::__construct($response->getReasonPhrase(), $response->getStatusCode());
-        $this->response = $response;
-        $this->apiError = $apiError;
+        $this->apiResponse = $apiResponse;
+        $message = $message ?: $this->getError()->getMessage();
+        parent::__construct($message, $this->getHttpCode());
     }
 
-    public function getResponse(): ResponseInterface
+    public function getHttpCode(): int
     {
-        return $this->response;
+        return $this->apiResponse->getHttpCode();
+    }
+
+    public function getResponse(): ApiResponse
+    {
+        return $this->apiResponse;
     }
 
     public function getError(): ApiError
     {
-        return $this->apiError;
+        return $this->apiResponse->getResponseError();
     }
 }

--- a/src/Exceptions/HttpException.php
+++ b/src/Exceptions/HttpException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Upmind\Sdk\Exception;
+namespace Upmind\Sdk\Exceptions;
 
 use Psr\Http\Message\ResponseInterface;
 use Upmind\Sdk\Data\ApiError;

--- a/src/Exceptions/ServerException.php
+++ b/src/Exceptions/ServerException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+/**
+ * Exception thrown for API server (5xx) errors.
+ *
+ * @see \Upmind\Sdk\Config::restfulExceptions()
+ */
+class ServerException extends HttpException
+{
+    //
+}

--- a/src/Exceptions/UpmindSdkException.php
+++ b/src/Exceptions/UpmindSdkException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+/**
+ * Exception thrown from the Upmind PHP SDK.
+ *
+ * @mixin \Throwable
+ */
+interface UpmindSdkException
+{
+    //
+}

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -25,7 +25,7 @@ class ValidationException extends ClientException
      */
     public function getValidationErrors(): array
     {
-        return $this->getError()->getData();
+        return $this->getApiError()->getData();
     }
 
     protected function getValidationErrorMessage(): string

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\Sdk\Exceptions;
+
+use Upmind\Sdk\Data\ApiResponse;
+
+/**
+ * Exception thrown for API validation (422) errors.
+ *
+ * @see \Upmind\Sdk\Config::restfulExceptions()
+ */
+class ValidationException extends ClientException
+{
+    public function __construct(ApiResponse $apiResponse, ?string $message = null)
+    {
+        $this->apiResponse = $apiResponse;
+        $message = $message ?: $this->getValidationErrorMessage();
+        parent::__construct($apiResponse, $message);
+    }
+
+    /**
+     * @return array<string,string[]>
+     */
+    public function getValidationErrors(): array
+    {
+        return $this->getError()->getData();
+    }
+
+    protected function getValidationErrorMessage(): string
+    {
+        $messages = [];
+
+        foreach ($this->getValidationErrors() as $field => $errors) {
+            $messages[] = sprintf('%s: %s', $field, implode(', ', $errors));
+        }
+
+        return sprintf('Validation Error: %s', implode("; ", $messages));
+    }
+}

--- a/src/Services/Clients/AddressService.php
+++ b/src/Services/Clients/AddressService.php
@@ -8,7 +8,7 @@ use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
 use Upmind\Sdk\Data\Services\CreateAddressParams;
 use Upmind\Sdk\Data\Services\UpdateAddressParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Services\AbstractService;
 
 /**

--- a/src/Services/Clients/ClientService.php
+++ b/src/Services/Clients/ClientService.php
@@ -6,7 +6,7 @@ namespace Upmind\Sdk\Services\Clients;
 
 use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Services\AbstractService;
 use Upmind\Sdk\Data\Services\CreateClientParams;
 use Upmind\Sdk\Data\Services\UpdateClientParams;

--- a/src/Services/Clients/CompanyService.php
+++ b/src/Services/Clients/CompanyService.php
@@ -8,7 +8,7 @@ use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
 use Upmind\Sdk\Data\Services\CreateCompanyParams;
 use Upmind\Sdk\Data\Services\UpdateCompanyParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Services\AbstractService;
 
 /**

--- a/src/Services/Clients/EmailService.php
+++ b/src/Services/Clients/EmailService.php
@@ -8,7 +8,7 @@ use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
 use Upmind\Sdk\Data\Services\CreateEmailParams;
 use Upmind\Sdk\Data\Services\UpdateEmailParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Services\AbstractService;
 
 /**

--- a/src/Services/Clients/PhoneService.php
+++ b/src/Services/Clients/PhoneService.php
@@ -8,7 +8,7 @@ use Upmind\Sdk\Data\ApiResponse;
 use Upmind\Sdk\Data\QueryParams;
 use Upmind\Sdk\Data\Services\CreatePhoneParams;
 use Upmind\Sdk\Data\Services\UpdatePhoneParams;
-use Upmind\Sdk\Exception\HttpException;
+use Upmind\Sdk\Exceptions\HttpException;
 use Upmind\Sdk\Services\AbstractService;
 
 /**

--- a/tests/phpunit/ApiTest.php
+++ b/tests/phpunit/ApiTest.php
@@ -27,7 +27,15 @@ class ApiTest extends TestCase
 
     protected function setUp(): void
     {
-        $config = new Config('hello-i-am-a-token');
+        $config = new Config(
+            'hello-i-am-a-token',
+            null,
+            false,
+            false,
+            'api.upmind.io',
+            'https',
+            false
+        );
         $logger = new NullLogger();
         $this->requestFactory = $this->getMockBuilder(RequestFactoryInterface::class)->getMock();
 


### PR DESCRIPTION
- Pluralise `Exception` namespace to be consistent with `Services` namespace
- Enable HttpExceptions by default in `Config`
- Modify HttpException to take an instance of `ApiResponse` instead of Psr7/Response
- Add sub-classes of HttpException for specific types of API error e.g., Auth, Validation
- Add marker interface UpmindSdkException for all library-defined exceptions
- Add a separate ConnectionException for timeout/dns/ssl errors which don't have an ApiResponse