### PR TITLE
JsonSerialize typehint

### DIFF
--- a/src/Data/AbstractParams.php
+++ b/src/Data/AbstractParams.php
@@ -85,7 +85,7 @@ abstract class AbstractParams implements JsonSerializable
         return $this->params;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }


### PR DESCRIPTION
To improve compatibility with different PHP versions, add covariant return typehint for jsonSerialize()